### PR TITLE
Send extra parameters in Extract call

### DIFF
--- a/AylienTextApi/TextApiClient/Endpoints/Extract.cs
+++ b/AylienTextApi/TextApiClient/Endpoints/Extract.cs
@@ -26,7 +26,7 @@ namespace Aylien.TextApi
     {
         public Extract(Configuration config) : base(config) { }
 
-        internal Response call(string url, string html, string bestImage)
+        internal Response call(string url, string html, string bestImage, Dictionary<string, string> extraParameters)
         {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
 
@@ -35,9 +35,16 @@ namespace Aylien.TextApi
 
             if (!String.IsNullOrWhiteSpace(html))
                 parameters["html"] = html;
-            
+
             if (!String.IsNullOrWhiteSpace(bestImage))
                 parameters["best_image"] = bestImage;
+
+            if (extraParameters != null && extraParameters.Count > 0)
+                foreach (var keyValue in extraParameters)
+                {
+                    if (!parameters.ContainsKey(keyValue.Key) && !String.IsNullOrWhiteSpace(keyValue.Key))
+                        parameters.Add(keyValue.Key, keyValue.Value);
+                }
 
             Connection connection = new Connection(Configuration.Endpoints["Extract"], parameters, configuration);
             var response = connection.request();
@@ -46,13 +53,13 @@ namespace Aylien.TextApi
             return response;
         }
 
-        public string Title { get; set;}
-        public string Article { get; set;}
-        public string Image { get; set;}
-        public string Author { get; set;}
-        public string[] Videos { get; set;}
-        public string[] Feeds { get; set;}
-        
+        public string Title { get; set; }
+        public string Article { get; set; }
+        public string Image { get; set; }
+        public string Author { get; set; }
+        public string[] Videos { get; set; }
+        public string[] Feeds { get; set; }
+
         private void populateData(string jsonString)
         {
             Extract m = JsonConvert.DeserializeObject<Extract>(jsonString);

--- a/AylienTextApi/TextApiClient/TextApiClient.cs
+++ b/AylienTextApi/TextApiClient/TextApiClient.cs
@@ -53,7 +53,7 @@ namespace Aylien.TextApi
         {
             Extract extract = new Aylien.TextApi.Extract(configuration);
             Response r = extract.call(url, html, bestImage.ToString());
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return extract;
         }
 
@@ -78,7 +78,7 @@ namespace Aylien.TextApi
         {
             Summarize summarize = new Aylien.TextApi.Summarize(configuration);
             Response r = summarize.call(text, title, url, mode, sentencesNumber.ToString(), sentencesPercentage.ToString());
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return summarize;
         }
 
@@ -95,7 +95,7 @@ namespace Aylien.TextApi
         {
             Classify classify = new Aylien.TextApi.Classify(configuration);
             Response r = classify.call(url, text, language);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return classify;
         }
 
@@ -113,7 +113,7 @@ namespace Aylien.TextApi
         {
             Sentiment sentiment = new Aylien.TextApi.Sentiment(configuration);
             Response r = sentiment.call(url, text, mode);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return sentiment;
         }
 
@@ -129,7 +129,7 @@ namespace Aylien.TextApi
         {
             Entities entities = new Aylien.TextApi.Entities(configuration);
             Response r = entities.call(url, text);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return entities;
         }
 
@@ -148,7 +148,7 @@ namespace Aylien.TextApi
         {
             Concepts concepts = new Aylien.TextApi.Concepts(configuration);
             Response r = concepts.call(url, text, language);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return concepts;
         }
 
@@ -165,7 +165,7 @@ namespace Aylien.TextApi
         {
             Hashtags hashtags = new Aylien.TextApi.Hashtags(configuration);
             Response r = hashtags.call(url, text, language);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return hashtags;
         }
 
@@ -180,7 +180,7 @@ namespace Aylien.TextApi
         {
             Language language = new Aylien.TextApi.Language(configuration);
             Response r = language.call(url, text);
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return language;
         }
 
@@ -195,14 +195,14 @@ namespace Aylien.TextApi
         {
             Related related = new Aylien.TextApi.Related(configuration);
             Response r = related.call(phrase, count.ToString());
-            extractRateLimitParameteres(r);
+            extractRateLimitParameters(r);
             return related;
         }
 
         /// <summary>
         /// Returns Rate Limit of API calls.
         /// </summary>
-        /// <returns> Retrun a Dictionary<string, int> of rate limit</returns>
+        /// <returns> Return a Dictionary<string, int> of rate limit</returns>
         public Dictionary<string, int> RateLimit
         {
             get
@@ -210,7 +210,7 @@ namespace Aylien.TextApi
                 if (rateLimit["Limit"] == -1 && rateLimit["Remaining"] == -1 && rateLimit["Reset"] == -1)
                 {
                     Response r = new Aylien.TextApi.Language(configuration).call(null, "Test");
-                    extractRateLimitParameteres(r);
+                    extractRateLimitParameters(r);
                 }
                 return rateLimit;
             }
@@ -220,7 +220,7 @@ namespace Aylien.TextApi
             }
         }
 
-        private void extractRateLimitParameteres(Response r){
+        private void extractRateLimitParameters(Response r){
             RateLimit = new Dictionary<string, int>
             {
                 {"Limit", int.Parse(r.ResponseHeader["X-RateLimit-Limit"])},

--- a/AylienTextApi/TextApiClient/TextApiClient.cs
+++ b/AylienTextApi/TextApiClient/TextApiClient.cs
@@ -49,10 +49,10 @@ namespace Aylien.TextApi
         /// <param name="html">HTML as string</param>
         /// <param name="bestImage">Whether extract the best image of the article</param>
         /// <returns>A <see cref="Extract"/></returns>
-        public Extract Extract(string url = null, string html = null, bool bestImage = false)
+        public Extract Extract(string url = null, string html = null, bool bestImage = false, Dictionary<string, string> extraParameters = null)
         {
             Extract extract = new Aylien.TextApi.Extract(configuration);
-            Response r = extract.call(url, html, bestImage.ToString());
+            Response r = extract.call(url, html, bestImage.ToString(), extraParameters);
             extractRateLimitParameters(r);
             return extract;
         }
@@ -220,7 +220,8 @@ namespace Aylien.TextApi
             }
         }
 
-        private void extractRateLimitParameters(Response r){
+        private void extractRateLimitParameters(Response r)
+        {
             RateLimit = new Dictionary<string, int>
             {
                 {"Limit", int.Parse(r.ResponseHeader["X-RateLimit-Limit"])},


### PR DESCRIPTION
Extract call method updated to take in a dictionary of extra parameters:

      var extractResult = client.Extract("http://www.theverge.com/2015/1/21/7863711/windows-10-tablet-hands-on-photos-video", bestImage: true, extraParameters: new Dictionary<string, string> { { "keep_html_formatting", "true" } });
